### PR TITLE
nccompress now accepts piped input like ncfind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - '2.7'
     - '3.6'
 before_install:
     - sudo apt-get -qq update

--- a/nccompress/__init__.py
+++ b/nccompress/__init__.py
@@ -1,0 +1,2 @@
+import nccompress.nccompress as nccompress
+import nccompress.nc2nc as nc2nc

--- a/nccompress/nccompress.py
+++ b/nccompress/nccompress.py
@@ -31,7 +31,7 @@ import math
 import operator
 import numpy as np
 import numpy.ma as ma
-import multiprocessing.dummy as mp
+import multiprocessing as mp
 
 if (sys.version_info > (3, 0)):
      # Python 3 code in this block
@@ -216,7 +216,6 @@ def run_compress(infile,outfile,level=5,shuffle=True,verbose=False,chunksize=64,
                 # Perform checks on compressed data, return result in state. Need to make
                 # this into an object ...
                 check_and_overwrite(state,verbose,maxcompress)
-            sys.stdout.flush()
             return state
         else:
             if identical_files is None:
@@ -249,7 +248,6 @@ def run_compress(infile,outfile,level=5,shuffle=True,verbose=False,chunksize=64,
             # this into an object ...
             check_and_overwrite(state,verbose,maxcompress)
 
-    sys.stdout.flush()
     return state
 
 def log_result(result):
@@ -269,7 +267,7 @@ def compress_files(path, files, tmpdir, overwrite, maxcompress, level, shuffle, 
     global result_list
     result_list[:] = []
 
-    pool = mp.Pool(processes=numproc) #,maxtasksperchild=50)
+    pool = mp.Pool(processes=numproc,maxtasksperchild=50)
 
     # Create our temporary directory
     outdir = os.path.join(path,tmpdir)
@@ -482,7 +480,6 @@ def main(args):
     # Also makes it easier to run some checks to ensure compression is ok, as all the files
     # are named the same, just in a separate temporary sub directory.
     for directory in filedict:
-        print(directory, filedict[directory])
         if len(filedict[directory]) == 0: continue
         compress_files(directory,
                        filedict[directory],

--- a/nccompress/nccompress.py
+++ b/nccompress/nccompress.py
@@ -377,7 +377,7 @@ def parse_args(arglist):
     parser.add_argument("-np","--numproc", help="Specify the number of processes to use in parallel operation", type=int, default=1)
     parser.add_argument("--nccopy", help="Use nccopy instead of nc2nc (default False)", action='store_true')
     parser.add_argument("--timing", help="Collect timing statistics when compressing each file (default False)", action='store_true')
-    parser.add_argument("inputs", help="netCDF files or directories (-r must be specified to recursively descend directories)", nargs='+')
+    parser.add_argument("inputs", help="netCDF files or directories (-r must be specified to recursively descend directories)", nargs='*', default=sys.stdin)
 
     return parser.parse_args(arglist)
 
@@ -397,6 +397,7 @@ def main(args):
     # Loop over all the inputs from the command line. These can be either file globs
     # or directory names. In either case we'll group them by directory
     for ncinput in args.inputs:
+        ncinput = ncinput.rstrip('\r\n')
         if not os.path.exists(ncinput):
             print ("Input does not exist: {} .. skipping".format(ncinput))
             continue


### PR DESCRIPTION
This means the result of a find command can be piped into nccompress to help speed up
compression by only selecting files that match a certain criteria.